### PR TITLE
Fix iOS 16 missing background color

### DIFF
--- a/Sources/UIViewEffectViewiOS14.swift
+++ b/Sources/UIViewEffectViewiOS14.swift
@@ -28,6 +28,7 @@ extension UIVisualEffectView {
             sourceOver?.setValue(newValue, forKeyPath: "color")
             sourceOver?.perform(Selector(("applyRequestedEffectToView:")), with: overlayView)
             applyChanges()
+            overlayView?.backgroundColor = newValue
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _VisualEffectView_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

### Description
<!--- Describe your changes in detail. -->
Background color for iOS 16 is not changing. This fix solves the issue