### PR TITLE
Update Minimum Deployment Target to iOS 14 (Dropping iOS 13 Support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## [Version 5.0.0](https://github.com/efremidze/VisualEffectView/releases/tag/5.0.0)
+
+- Dropped iOS 13 support (use 4.x.x for iOS 9+ support)
+
 ## [Version 4.1.5](https://github.com/efremidze/VisualEffectView/releases/tag/4.1.5)
 
 - Support SwiftUI (#37)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ $ pod try VisualEffectView
 
 ## Requirements
 
-- iOS 9.0+
-- iOS 14.0 + (SwiftUI support)
-- Xcode 9.0+
+- iOS 14.0+ (SwiftUI support)
 - Swift 5 (VisualEffectView 4.x), Swift 4 (VisualEffectView 3.x), Swift 3 (VisualEffectView 2.x), Swift 2 (VisualEffectView 1.x)
 
 ## Usage

--- a/Sources/UIViewEffectView+Helpers.swift
+++ b/Sources/UIViewEffectView+Helpers.swift
@@ -7,33 +7,7 @@
 
 import UIKit
 
-@available(iOS 14, *)
 extension UIVisualEffectView {
-    var ios14_blurRadius: CGFloat {
-        get {
-            return gaussianBlur?.requestedValues?["inputRadius"] as? CGFloat ?? 0
-        }
-        set {
-            prepareForChanges()
-            gaussianBlur?.requestedValues?["inputRadius"] = newValue
-            applyChanges()
-        }
-    }
-    var ios14_colorTint: UIColor? {
-        get {
-            return sourceOver?.value(forKeyPath: "color") as? UIColor
-        }
-        set {
-            prepareForChanges()
-            sourceOver?.setValue(newValue, forKeyPath: "color")
-            sourceOver?.perform(Selector(("applyRequestedEffectToView:")), with: overlayView)
-            applyChanges()
-            overlayView?.backgroundColor = newValue
-        }
-    }
-}
-
-private extension UIVisualEffectView {
     var backdropView: UIView? {
         return subview(of: NSClassFromString("_UIVisualEffectBackdropView"))
     }
@@ -55,7 +29,7 @@ private extension UIVisualEffectView {
     }
 }
 
-private extension NSObject {
+extension NSObject {
     var requestedValues: [String: Any]? {
         get { return value(forKeyPath: "requestedValues") as? [String: Any] }
         set { setValue(newValue, forKeyPath: "requestedValues") }

--- a/Sources/VisualEffectView+SwiftUI.swift
+++ b/Sources/VisualEffectView+SwiftUI.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 14, *)
 public struct VisualEffect: UIViewRepresentable {
     let colorTint: Color?
     let colorTintAlpha: CGFloat
@@ -46,7 +45,6 @@ public struct VisualEffect: UIViewRepresentable {
     }
 }
 
-@available(iOS 14, *)
 struct VisualEffect_Previews: PreviewProvider {
     static var previews: some View {
         ZStack {
@@ -60,7 +58,6 @@ struct VisualEffect_Previews: PreviewProvider {
     }
 }
 
-@available(iOS 14, *)
 private extension Color {
     func uiColor() -> UIColor {
         return UIColor(self)

--- a/Sources/VisualEffectView.swift
+++ b/Sources/VisualEffectView.swift
@@ -22,18 +22,14 @@ open class VisualEffectView: UIVisualEffectView {
      */
     open var colorTint: UIColor? {
         get {
-            if #available(iOS 14, *) {
-                return ios14_colorTint
-            } else {
-                return _value(forKey: .colorTint)
-            }
+            return sourceOver?.value(forKeyPath: "color") as? UIColor
         }
         set {
-            if #available(iOS 14, *) {
-                ios14_colorTint = newValue
-            } else {
-                _setValue(newValue, forKey: .colorTint)
-            }
+            prepareForChanges()
+            sourceOver?.setValue(newValue, forKeyPath: "color")
+            sourceOver?.perform(Selector(("applyRequestedEffectToView:")), with: overlayView)
+            applyChanges()
+            overlayView?.backgroundColor = newValue
         }
     }
     
@@ -45,13 +41,7 @@ open class VisualEffectView: UIVisualEffectView {
      */
     open var colorTintAlpha: CGFloat {
         get { return _value(forKey: .colorTintAlpha) ?? 0.0 }
-        set {
-            if #available(iOS 14, *) {
-                ios14_colorTint = ios14_colorTint?.withAlphaComponent(newValue)
-            } else {
-                _setValue(newValue, forKey: .colorTintAlpha)
-            }
-        }
+        set { colorTint = colorTint?.withAlphaComponent(newValue) }
     }
     
     /**
@@ -61,18 +51,12 @@ open class VisualEffectView: UIVisualEffectView {
      */
     open var blurRadius: CGFloat {
         get {
-            if #available(iOS 14, *) {
-                return ios14_blurRadius
-            } else {
-                return _value(forKey: .blurRadius) ?? 0.0
-            }
+            return gaussianBlur?.requestedValues?["inputRadius"] as? CGFloat ?? 0
         }
         set {
-            if #available(iOS 14, *) {
-                ios14_blurRadius = newValue
-            } else {
-                _setValue(newValue, forKey: .blurRadius)
-            }
+            prepareForChanges()
+            gaussianBlur?.requestedValues?["inputRadius"] = newValue
+            applyChanges()
         }
     }
     
@@ -116,9 +100,6 @@ private extension VisualEffectView {
     /// Sets the value for the key on the blurEffect.
     func _setValue<T>(_ value: T?, forKey key: Key) {
         blurEffect.setValue(value, forKeyPath: key.rawValue)
-        if #unavailable(iOS 14) {
-            self.effect = blurEffect
-        }
     }
     
     enum Key: String {

--- a/VisualEffectView.podspec
+++ b/VisualEffectView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = "VisualEffectView"
-    s.version          = "4.1.5"
+    s.version          = "5.0.0"
     s.license          = 'MIT'
     s.homepage         = "https://github.com/efremidze/VisualEffectView"
     s.author           = { "Lasha Efremidze" => "efremidzel@hotmail.com" }
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/efremidze/VisualEffectView.git', :tag => s.version }
     s.source_files     = "Sources/*.swift"
     s.swift_version = '5.0'
-    s.ios.deployment_target = '9.0'
+    s.ios.deployment_target = '14.0'
 end

--- a/VisualEffectView.xcodeproj/project.pbxproj
+++ b/VisualEffectView.xcodeproj/project.pbxproj
@@ -16,12 +16,12 @@
 		8B3DFCE01E07D8F5009EAFA2 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DFCDF1E07D8F5009EAFA2 /* VisualEffectView.swift */; };
 		8BD4B7E61E8A563A00BD74C6 /* VisualEffectView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B3243FE1E07D7CB00712FEA /* VisualEffectView.framework */; };
 		8BD4B7E71E8A563A00BD74C6 /* VisualEffectView.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B3243FE1E07D7CB00712FEA /* VisualEffectView.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C0864C842A6FB2D2006B0F49 /* VisualEffectView_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864C832A6FB2D2006B0F49 /* VisualEffectView_SwiftUI.swift */; };
+		C0864C842A6FB2D2006B0F49 /* VisualEffectView+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0864C832A6FB2D2006B0F49 /* VisualEffectView+SwiftUI.swift */; };
 		F449249E206F2D5100117F6B /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = F449249B206F2D5100117F6B /* README.md */; };
 		F449249F206F2D5100117F6B /* VisualEffectView.podspec in Resources */ = {isa = PBXBuildFile; fileRef = F449249C206F2D5100117F6B /* VisualEffectView.podspec */; };
 		F44924A0206F2D5100117F6B /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = F449249D206F2D5100117F6B /* CHANGELOG.md */; };
 		F48F0D532236406400F54233 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F0D522236406400F54233 /* Extensions.swift */; };
-		F4BE05CB25108C0000500B57 /* UIViewEffectView_iOS14.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BE05CA25108C0000500B57 /* UIViewEffectView_iOS14.swift */; };
+		F4BE05CB25108C0000500B57 /* UIViewEffectView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BE05CA25108C0000500B57 /* UIViewEffectView+Helpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,12 +60,12 @@
 		8B3244191E07D7D900712FEA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8B32441B1E07D7D900712FEA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8B3DFCDF1E07D8F5009EAFA2 /* VisualEffectView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
-		C0864C832A6FB2D2006B0F49 /* VisualEffectView_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisualEffectView_SwiftUI.swift; sourceTree = "<group>"; };
+		C0864C832A6FB2D2006B0F49 /* VisualEffectView+SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VisualEffectView+SwiftUI.swift"; sourceTree = "<group>"; };
 		F449249B206F2D5100117F6B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		F449249C206F2D5100117F6B /* VisualEffectView.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VisualEffectView.podspec; sourceTree = "<group>"; };
 		F449249D206F2D5100117F6B /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		F48F0D522236406400F54233 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		F4BE05CA25108C0000500B57 /* UIViewEffectView_iOS14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewEffectView_iOS14.swift; sourceTree = "<group>"; };
+		F4BE05CA25108C0000500B57 /* UIViewEffectView+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewEffectView+Helpers.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,8 +112,8 @@
 			isa = PBXGroup;
 			children = (
 				8B3DFCDF1E07D8F5009EAFA2 /* VisualEffectView.swift */,
-				F4BE05CA25108C0000500B57 /* UIViewEffectView_iOS14.swift */,
-				C0864C832A6FB2D2006B0F49 /* VisualEffectView_SwiftUI.swift */,
+				F4BE05CA25108C0000500B57 /* UIViewEffectView+Helpers.swift */,
+				C0864C832A6FB2D2006B0F49 /* VisualEffectView+SwiftUI.swift */,
 				8B3244011E07D7CB00712FEA /* VisualEffectView.h */,
 				8B3244021E07D7CB00712FEA /* Info.plist */,
 			);
@@ -256,8 +256,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B3DFCE01E07D8F5009EAFA2 /* VisualEffectView.swift in Sources */,
-				F4BE05CB25108C0000500B57 /* UIViewEffectView_iOS14.swift in Sources */,
-				C0864C842A6FB2D2006B0F49 /* VisualEffectView_SwiftUI.swift in Sources */,
+				F4BE05CB25108C0000500B57 /* UIViewEffectView+Helpers.swift in Sources */,
+				C0864C842A6FB2D2006B0F49 /* VisualEffectView+SwiftUI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
<!-- Thanks for contributing to _VisualEffectView_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Description
This Pull Request updates the minimum deployment target of the framework to iOS 14, thereby dropping support for iOS 13. The following changes have been implemented:

### Impact
- Developers integrating this framework will need to target iOS 14 or later in their applications.
- For projects that still require support for iOS 9 through iOS 13, version 4.x.x of the framework remains available.
