### PR TITLE
Update Swift Tools Version to 5.3 to Fix Minimum iOS Version Compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
This PR updates the Swift tools version from 5.0 to 5.3 to address a breaking change caused by raising the minimum supported iOS version to iOS 14. Swift tools version 5.0 does not support iOS 14 as the minimum version, which caused SPM failures. By updating to Swift tools version 5.3, which provides compatibility for iOS 14, the issue is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Swift tools version requirement to 5.3, ensuring compatibility with newer Swift features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->