### PR TITLE
Release 5.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## [Version 5.0.8](https://github.com/efremidze/VisualEffectView/releases/tag/5.0.8)
+
+- Readded saturation
+
 ## [Version 5.0.7](https://github.com/efremidze/VisualEffectView/releases/tag/5.0.7)
 
 - Update platforms to iOS14 in Package.swift by @Phyber64 in https://github.com/efremidze/VisualEffectView/pull/45

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ var colorTint: UIColor // tint color. default is nil
 var colorTintAlpha: CGFloat // tint color alpha. default is 0
 var blurRadius: CGFloat // blur radius. default is 0
 var scale: CGFloat // scale factor. default is 1
+var saturation: CGFloat // saturation factor. default is 1
 ```
 
 If you want `colorTintAlpha` to be different from `0`, make sure you always set it right after setting the `colorTint` or it may not be applied as expected.

--- a/Sources/VisualEffectView/VisualEffectView+SwiftUI.swift
+++ b/Sources/VisualEffectView/VisualEffectView+SwiftUI.swift
@@ -38,6 +38,15 @@ public struct VisualEffect: UIViewRepresentable {
     let blurRadius: CGFloat
 
     /**
+     The saturation factor.
+     
+     Values above 1.0 increase saturation, values below 1.0 decrease saturation, and 1.0 maintains original saturation.
+     
+     The default value is `1.0`.
+     */
+    let saturation: CGFloat
+
+    /**
      The scale factor for the blur effect.
      
      The default value is `1.0`.
@@ -51,12 +60,14 @@ public struct VisualEffect: UIViewRepresentable {
         - colorTint: The tint color to apply to the blur effect. Defaults to `nil`.
         - colorTintAlpha: The alpha component of the tint color. Defaults to `0.0`.
         - blurRadius: The radius of the blur effect. Defaults to `0.0`.
+        - saturation: The saturation adjustment factor. Values above 1.0 increase saturation, values below 1.0 decrease saturation. Defaults to `1.0`.
         - scale: The scale factor for the blur effect. Defaults to `1.0`.
      */
-    public init(colorTint: Color? = nil, colorTintAlpha: CGFloat = 0, blurRadius: CGFloat = 0, scale: CGFloat = 1) {
+    public init(colorTint: Color? = nil, colorTintAlpha: CGFloat = 0, blurRadius: CGFloat = 0, saturation: CGFloat = 1, scale: CGFloat = 1) {
         self.colorTint = colorTint
         self.colorTintAlpha = colorTintAlpha
         self.blurRadius = blurRadius
+        self.saturation = saturation
         self.scale = scale
     }
     
@@ -69,6 +80,7 @@ public struct VisualEffect: UIViewRepresentable {
         }
         view.colorTintAlpha = colorTintAlpha
         view.blurRadius = blurRadius
+        view.saturation = saturation
         view.scale = scale
         
         return view
@@ -80,6 +92,7 @@ public struct VisualEffect: UIViewRepresentable {
         }
         uiView.colorTintAlpha = colorTintAlpha
         uiView.blurRadius = blurRadius
+        uiView.saturation = saturation
         uiView.scale = scale
     }
 }
@@ -90,7 +103,7 @@ public struct VisualEffect: UIViewRepresentable {
             .frame(width: 400, height: 400)
         Color.red
             .frame(width: 200, height: 100)
-        VisualEffect(colorTint: .white, colorTintAlpha: 0.5, blurRadius: 18)
+        VisualEffect(colorTint: .white, colorTintAlpha: 0.5, blurRadius: 18, saturation: 2.0)
             .frame(width: 300, height: 200)
     }
 }

--- a/Sources/VisualEffectView/VisualEffectView.swift
+++ b/Sources/VisualEffectView/VisualEffectView.swift
@@ -61,6 +61,18 @@ open class VisualEffectView: UIVisualEffectView {
     }
     
     /**
+     Saturation factor.
+     
+     Values above 1.0 increase saturation, values below 1.0 decrease saturation, and 1.0 maintains original saturation.
+     
+     The default value is 1.0.
+     */
+    open var saturation: CGFloat {
+        get { return _value(forKey: .saturationDeltaFactor) ?? 1.0 }
+        set { _setValue(newValue, forKey: .saturationDeltaFactor) }
+    }
+    
+    /**
      Scale factor.
      
      The scale factor determines how content in the view is mapped from the logical coordinate space (measured in points) to the device coordinate space (measured in pixels).
@@ -103,7 +115,7 @@ private extension VisualEffectView {
     }
     
     enum Key: String {
-        case colorTint, colorTintAlpha, blurRadius, scale
+        case colorTint, colorTintAlpha, blurRadius, saturationDeltaFactor, scale
     }
     
 }

--- a/VisualEffectView.podspec
+++ b/VisualEffectView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = "VisualEffectView"
-    s.version          = "5.0.7"
+    s.version          = "5.0.8"
     s.license          = 'MIT'
     s.homepage         = "https://github.com/efremidze/VisualEffectView"
     s.author           = { "Lasha Efremidze" => "efremidzel@hotmail.com" }

--- a/VisualEffectView.xcodeproj/project.pbxproj
+++ b/VisualEffectView.xcodeproj/project.pbxproj
@@ -436,7 +436,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.1.5;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.VisualEffectView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -463,7 +462,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.7;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.VisualEffectView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -498,7 +496,6 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example;
@@ -537,7 +534,6 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
<!-- Thanks for contributing to _VisualEffectView_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've tested my changes.
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

### Description
<!--- Describe your changes in detail. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a saturation control to VisualEffectView and its SwiftUI wrapper, enabling adjustment of blur saturation. Defaults to 1; supports values below/above 1 for desaturation/boosted saturation. SwiftUI initializer now accepts a saturation parameter, and previews demonstrate usage.

- Documentation
  - Updated README Customization section to document the new saturation property, including default behavior and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->